### PR TITLE
Adding a WalletNames datatype and factory to represent valid wallet

### DIFF
--- a/WalletExplorerDatasetUtility/src/main/java/net/stevenuray/walletexplorer/walletnames/TextFileWalletNamesFactory.java
+++ b/WalletExplorerDatasetUtility/src/main/java/net/stevenuray/walletexplorer/walletnames/TextFileWalletNamesFactory.java
@@ -1,0 +1,32 @@
+package net.stevenuray.walletexplorer.walletnames;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+
+import net.stevenuray.walletexplorer.downloader.WalletExplorerAPIConfigSingleton;
+
+public class TextFileWalletNamesFactory implements WalletNamesFactory {
+
+	@Override
+	public WalletNames getWalletNames() {
+		try{
+			Iterator<String> walletNamesIterator = getWalletNamesFromFile();
+			WalletNames walletNames = new WalletNames(walletNamesIterator);
+			return walletNames;
+		} catch(Exception e){
+			throw new RuntimeException(e);
+		}
+	}
+	
+	private static Iterator<String> getWalletNamesFromFile() throws Exception {	
+		Charset encoding = WalletExplorerAPIConfigSingleton.ENCODING;
+		File file = new File("resources/wallets.txt");
+		Path path = file.toPath();
+		Iterator<String> wallets = Files.readAllLines(path, encoding).iterator();
+		return wallets;
+	}
+
+}

--- a/WalletExplorerDatasetUtility/src/main/java/net/stevenuray/walletexplorer/walletnames/WalletNames.java
+++ b/WalletExplorerDatasetUtility/src/main/java/net/stevenuray/walletexplorer/walletnames/WalletNames.java
@@ -1,0 +1,31 @@
+package net.stevenuray.walletexplorer.walletnames;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**Represents a set of wallet names that represent bitcoin companies as WalletExplorer.com defines them. 
+ * All names in WalletNames are assumed to be valid names that will return transactions when given to 
+ * WalletExplorer's API.
+ * @author Steven Uray
+ */
+public class WalletNames implements Iterable<String>{
+	private final Set<String> walletNamesSet = new HashSet<String>();
+	
+	public WalletNames(Iterator<String> walletNames){
+		while(walletNames.hasNext()){
+			String nextWalletName = walletNames.next();
+			walletNamesSet.add(nextWalletName);
+		}		
+	}
+	
+	public Set<String> getWalletNamesSetUnmodifiable(){
+		return Collections.unmodifiableSet(walletNamesSet);
+	}
+	
+	@Override
+	public Iterator<String> iterator() {
+		return walletNamesSet.iterator();
+	}	
+}

--- a/WalletExplorerDatasetUtility/src/main/java/net/stevenuray/walletexplorer/walletnames/WalletNamesFactory.java
+++ b/WalletExplorerDatasetUtility/src/main/java/net/stevenuray/walletexplorer/walletnames/WalletNamesFactory.java
@@ -1,0 +1,6 @@
+package net.stevenuray.walletexplorer.walletnames;
+
+/**Creates a WalletNames object representing a set of wallet names on WalletExplorer.com **/
+public interface WalletNamesFactory {
+	public WalletNames getWalletNames();
+}


### PR DESCRIPTION
names on WalletExplorer.com. Wallet names are tied to individual bitcoin
companies or organizations.